### PR TITLE
Fix some file upload issues

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,9 @@
 package podrick
 
-import "io"
+import (
+	"io"
+	"os"
+)
 
 // ContainerConfig is used by runtimes to start
 // containers.
@@ -26,9 +29,10 @@ type Ulimit struct {
 }
 
 // File describes a file in a container.
-// All fields are mandatory
+// All fields are mandatory.
 type File struct {
 	Content io.Reader
 	Path    string
 	Size    int
+	Mode    os.FileMode
 }

--- a/runtimes/docker/file.go
+++ b/runtimes/docker/file.go
@@ -33,7 +33,7 @@ func uploadFiles(ctx context.Context, client *docker.Client, cID string, files .
 			}
 			err = archive.WriteHeader(&tar.Header{
 				Name: f.Path,
-				Mode: 0644,
+				Mode: int64(f.Mode),
 				Size: int64(f.Size),
 			})
 			if err != nil {

--- a/runtimes/podman/file.go
+++ b/runtimes/podman/file.go
@@ -2,6 +2,7 @@ package podman
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -40,6 +41,12 @@ func uploadFile(ctx context.Context, mountDir string, file podrick.File) (err er
 		return fmt.Errorf("file paths must be absolute: %q", file.Path)
 	}
 	dest := filepath.Join(mountDir, path)
+	if _, err := os.Stat(filepath.Dir(dest)); errors.Is(err, os.ErrNotExist) {
+		err := os.MkdirAll(filepath.Dir(dest), 0644)
+		if err != nil {
+			return fmt.Errorf("failed to create parent directory: %w", err)
+		}
+	}
 	target, err := os.Create(dest)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)

--- a/runtimes/podman/file.go
+++ b/runtimes/podman/file.go
@@ -62,5 +62,10 @@ func uploadFile(ctx context.Context, mountDir string, file podrick.File) (err er
 		return fmt.Errorf("failed to copy file contents: %w", err)
 	}
 
+	err = os.Chmod(dest, file.Mode)
+	if err != nil {
+		return fmt.Errorf("failed to set file permissions: %w", err)
+	}
+
 	return nil
 }

--- a/runtimes/podman/file.go
+++ b/runtimes/podman/file.go
@@ -42,7 +42,7 @@ func uploadFile(ctx context.Context, mountDir string, file podrick.File) (err er
 	}
 	dest := filepath.Join(mountDir, path)
 	if _, err := os.Stat(filepath.Dir(dest)); errors.Is(err, os.ErrNotExist) {
-		err := os.MkdirAll(filepath.Dir(dest), 0644)
+		err := os.MkdirAll(filepath.Dir(dest), 0777)
 		if err != nil {
 			return fmt.Errorf("failed to create parent directory: %w", err)
 		}


### PR DESCRIPTION
## runtimes/podman: recursively create dirs

Recursively create directories for any uploaded
files, should they not already exist.

Note that this is still broken, subject to #12.

Recursively create directories for any uploaded
files, should they not already exist.

## runtimes/podman: use silly file permissions

This works around some permission errors

## Add file mode to File 