### PR TITLE
Increse liveness check timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
-	github.com/varlink/go v0.0.0-20191018142704-4ecdbb8a36c2
+	github.com/varlink/go v0.3.0
 	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/varlink/go v0.0.0-20191018142704-4ecdbb8a36c2 h1:KcTzc0lm6PuIl9sAz5GMSGQyDhbJOa9NC3u69PVIc7Y=
-github.com/varlink/go v0.0.0-20191018142704-4ecdbb8a36c2/go.mod h1:DKg9Y2ctoNkesREGAEak58l+jOC6JU2aqZvUYs5DynU=
+github.com/varlink/go v0.3.0 h1:7IDKK8X3W9qqgw7oisE2RgtdTOxBxDwX5RDm2qVoKT8=
+github.com/varlink/go v0.3.0/go.mod h1:DKg9Y2ctoNkesREGAEak58l+jOC6JU2aqZvUYs5DynU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/podrick.go
+++ b/podrick.go
@@ -62,7 +62,7 @@ func StartContainer(ctx context.Context, repo, tag, port string, opts ...Option)
 
 	if conf.liveCheck != nil {
 		bk := backoff.NewExponentialBackOff()
-		bk.MaxElapsedTime = 10 * time.Second
+		bk.MaxElapsedTime = 30 * time.Second
 		cbk := backoff.WithContext(bk, ctx)
 		err = backoff.RetryNotify(
 			func() error {

--- a/runtimes/podman/iopodman/Makefile
+++ b/runtimes/podman/iopodman/Makefile
@@ -1,6 +1,6 @@
 update:
 	rm io.podman.varlink
-	wget https://raw.githubusercontent.com/containers/libpod/master/cmd/podman/varlink/io.podman.varlink
+	wget https://raw.githubusercontent.com/containers/libpod/v1.5.1/cmd/podman/varlink/io.podman.varlink
 
 generate:
 	go install github.com/varlink/go/cmd/varlink-go-interface-generator

--- a/runtimes/podman/iopodman/io.podman.varlink
+++ b/runtimes/podman/iopodman/io.podman.varlink
@@ -7,7 +7,8 @@ type Volume (
   labels: [string]string,
   mountPoint: string,
   driver: string,
-  options: [string]string
+  options: [string]string,
+  scope: string
 )
 
 type NotImplemented (
@@ -249,7 +250,7 @@ type InfoStore (
     run_root: string
 )
 
-# InfoPodman provides details on the Podman binary
+# InfoPodman provides details on the podman binary
 type InfoPodmanBinary (
     compiler: string,
     go_version: string,
@@ -274,8 +275,6 @@ type Sockets(
 )
 
 # Create is an input structure for creating containers.
-# args[0] is the image name or id
-# args[1-] are the new commands if changed
 type Create (
     args: []string,
     addHost: ?[]string,
@@ -348,7 +347,6 @@ type Create (
     privileged: ?bool,
     publish: ?[]string,
     publishAll: ?bool,
-    pull: ?string,
     quiet: ?bool,
     readonly: ?bool,
     readonlytmpfs: ?bool,
@@ -363,7 +361,7 @@ type Create (
     subuidname: ?string,
     subgidname: ?string,
     sysctl: ?[]string,
-    systemd: ?string,
+    systemd: ?bool,
     tmpfs: ?[]string,
     tty: ?bool,
     uidmap: ?[]string,
@@ -546,10 +544,6 @@ method GetContainersByStatus(status: []string) -> (containerS: []Container)
 
 method Top (nameOrID: string, descriptors: []string) -> (top: []string)
 
-# HealthCheckRun executes defined container's healthcheck command
-# and returns the container's health status.
-method HealthCheckRun (nameOrID: string) -> (healthCheckStatus: string)
-
 # GetContainer returns information about a single container.  If a container
 # with the given id doesn't exist, a [ContainerNotFound](#ContainerNotFound)
 # error will be returned.  See also [ListContainers](ListContainers) and
@@ -727,12 +721,10 @@ method GetAttachSockets(name: string) -> (sockets: Sockets)
 # or name, a [ContainerNotFound](#ContainerNotFound) error is returned.
 method WaitContainer(name: string, interval: int) -> (exitcode: int)
 
-# RemoveContainer requires the name or ID of a container as well as a boolean that
-# indicates whether a container should be forcefully removed (e.g., by stopping it), and a boolean
+# RemoveContainer requires the name or ID of container as well a boolean representing whether a running container can be stopped and removed, and a boolean
 # indicating whether to remove builtin volumes. Upon successful removal of the
 # container, its ID is returned.  If the
 # container cannot be found by name or ID, a [ContainerNotFound](#ContainerNotFound) error will be returned.
-# See also [EvictContainer](EvictContainer).
 # #### Example
 # ~~~
 # $ varlink call -m unix:/run/podman/io.podman/io.podman.RemoveContainer '{"name": "62f4fd98cb57"}'
@@ -741,20 +733,6 @@ method WaitContainer(name: string, interval: int) -> (exitcode: int)
 # }
 # ~~~
 method RemoveContainer(name: string, force: bool, removeVolumes: bool) -> (container: string)
-
-# EvictContainer requires the name or ID of a container as well as a boolean that
-# indicates to remove builtin volumes. Upon successful eviction of the container,
-# its ID is returned.  If the container cannot be found by name or ID,
-# a [ContainerNotFound](#ContainerNotFound) error will be returned.
-# See also [RemoveContainer](RemoveContainer).
-# #### Example
-# ~~~
-# $ varlink call -m unix:/run/podman/io.podman/io.podman.EvictContainer '{"name": "62f4fd98cb57"}'
-# {
-#   "container": "62f4fd98cb57f529831e8f90610e54bba74bd6f02920ffb485e15376ed365c20"
-# }
-# ~~~
-method EvictContainer(name: string, removeVolumes: bool) -> (container: string)
 
 # DeleteStoppedContainers will delete all containers that are not running. It will return a list the deleted
 # container IDs.  See also [RemoveContainer](RemoveContainer).
@@ -781,43 +759,8 @@ method ListImages() -> (images: []Image)
 method GetImage(id: string) -> (image: Image)
 
 # BuildImage takes a [BuildInfo](#BuildInfo) structure and builds an image.  At a minimum, you must provide the
-# contextDir tarball path, the 'dockerfiles' path, and 'output' option in the BuildInfo structure.  The 'output'
-# options is the name of the of the resulting build. It will return a [MoreResponse](#MoreResponse) structure
+# 'dockerfile' and 'tags' options in the BuildInfo structure. It will return a [MoreResponse](#MoreResponse) structure
 # that contains the build logs and resulting image ID.
-# #### Example
-# ~~~
-# $ sudo varlink call -m unix:///run/podman/io.podman/io.podman.BuildImage '{"build":{"contextDir":"/tmp/t/context.tar","dockerfiles":["Dockerfile"], "output":"foobar"}}'
-# {
-#  "image": {
-#    "id": "",
-#    "logs": [
-#      "STEP 1: FROM alpine\n"
-#    ]
-#  }
-# }
-# {
-#  "image": {
-#    "id": "",
-#    "logs": [
-#      "STEP 2: COMMIT foobar\n"
-#    ]
-#  }
-# }
-# {
-#  "image": {
-#    "id": "",
-#    "logs": [
-#      "b7b28af77ffec6054d13378df4fdf02725830086c7444d9c278af25312aa39b9\n"
-#    ]
-#  }
-# }
-# {
-#  "image": {
-#    "id": "b7b28af77ffec6054d13378df4fdf02725830086c7444d9c278af25312aa39b9",
-#    "logs": []
-#  }
-# }
-# ~~~
 method BuildImage(build: BuildInfo) -> (image: MoreResponse)
 
 # This function is not implemented yet.
@@ -1263,7 +1206,7 @@ method ReceiveFile(path: string, delete: bool) -> (len: int)
 method VolumeCreate(options: VolumeCreateOpts) -> (volumeName: string)
 
 # VolumeRemove removes a volume on a remote host
-method VolumeRemove(options: VolumeRemoveOpts) -> (successes: []string, failures: [string]string)
+method VolumeRemove(options: VolumeRemoveOpts) -> (volumeNames: []string)
 
 # GetVolumes gets slice of the volumes on a remote host
 method GetVolumes(args: []string, all: bool) -> (volumes: []Volume)
@@ -1293,6 +1236,8 @@ method GetLayersMapWithImageInfo() -> (layerMap: string)
 
 # BuildImageHierarchyMap is for the development of Podman and should not be used.
 method BuildImageHierarchyMap(name: string) -> (imageInfo: string)
+
+method GenerateSystemd(name: string, restart: string, timeout: int, useName: bool) -> (unit: string)
 
 # ImageNotFound means the image could not be found by the provided name or ID in local storage.
 error ImageNotFound (id: string, reason: string)


### PR DESCRIPTION
Today I had the pleasure of testing against a popular
JVM based document database, and it took longer than
10 seconds for the container to be started. At the time
of designing podrick I considered this timeout to be
extremely unlikely to be hit, but I hadn't yet met the
fury of the JVM cold start. A limit of 30 seconds will
_surely_ be enough.